### PR TITLE
Avoid nil deref in random

### DIFF
--- a/bn256.go
+++ b/bn256.go
@@ -26,7 +26,7 @@ import (
 func randomK(r io.Reader) (k *big.Int, err error) {
 	for {
 		k, err = rand.Int(r, Order)
-		if k.Sign() > 0 || err != nil {
+		if err != nil || k.Sign() > 0 {
 			return
 		}
 	}


### PR DESCRIPTION
This fixes a small flaw in the random generation of points. If the supplied source goes EOF, then the read will fail, and the `k` will be `nil`. 
Changing the order of the checks fixes it. 