### PR TITLE
Update gfp12.go

### DIFF
--- a/gfp12.go
+++ b/gfp12.go
@@ -136,8 +136,8 @@ func (e *gfP12) Mul(a, b *gfP12) *gfP12 {
 }
 
 func (e *gfP12) MulScalar(a *gfP12, b *gfP6) *gfP12 {
-	e.x.Mul(&e.x, b)
-	e.y.Mul(&e.y, b)
+	e.x.Mul(&a.x, b)
+	e.y.Mul(&a.y, b)
 	return e
 }
 


### PR DESCRIPTION
- fix simple bug in gfp12.MulScalar
- used e in input values instead of a (check lines)