### PR TITLE
Remove usage of reserved registers on arm64

### DIFF
--- a/gfp_arm64.s
+++ b/gfp_arm64.s
@@ -105,7 +105,7 @@ TEXT ·gfpMul(SB),0,$0-24
 	MOVD b+16(FP), R0
 	loadBlock(0(R0), R5,R6,R7,R8)
 
-	mul(R9,R10,R11,R12,R13,R14,R15,R16)
+	mul(R9,R10,R11,R12,R13,R14,R15,R16,R17,EMPTY)
 	gfpReduce()
 
 	MOVD c+0(FP), R0

--- a/mul_arm64.h
+++ b/mul_arm64.h
@@ -52,9 +52,9 @@
 	UMULH R4, R5, R26 \
 	MUL R4, R6, R0 \
 	ADDS R0, R26 \
-	UMULH R4, R6, R27 \
+	UMULH R4, R6, R5 \
 	MUL R4, R7, R0 \
-	ADCS R0, R27 \
+	ADCS R0, R5 \
 	UMULH R4, R7, R6 \
 	MUL R4, R8, R0 \
 	ADCS R0, R6 \
@@ -62,7 +62,7 @@
 	ADCS ZR, c7 \
 	ADDS R1, c3 \
 	ADCS R26, c4 \
-	ADCS R27, c5 \
+	ADCS R5, c5 \
 	ADCS R6, c6 \
 	ADCS  ZR, c7
 
@@ -121,6 +121,7 @@
 	ADCS R16, R24 \
 	ADCS  ZR, R0 \
 	\
+	MOVD ·p2+0(SB), R5 \ // Restore R5
 	MOVD ·p2+8(SB), R6 \ // Restore R6
 	\ // Our output is R21:R22:R23:R24. Reduce mod p if necessary.
 	SUBS R5, R21, R10 \

--- a/mul_arm64.h
+++ b/mul_arm64.h
@@ -16,9 +16,9 @@
 	UMULH R2, R5, R26 \
 	MUL R2, R6, R0 \
 	ADDS R0, R26 \
-	UMULH R2, R6, R27 \
+	UMULH R2, R6, c6 \
 	MUL R2, R7, R0 \
-	ADCS R0, R27 \
+	ADCS R0, c6 \
 	UMULH R2, R7, c7 \
 	MUL R2, R8, R0 \
 	ADCS R0, c7 \
@@ -26,7 +26,7 @@
 	ADCS ZR, c5 \
 	ADDS R1, c1 \
 	ADCS R26, c2 \
-	ADCS R27, c3 \
+	ADCS c6, c3 \
 	ADCS c7, c4 \
 	ADCS  ZR, c5 \
 	\

--- a/mul_arm64.h
+++ b/mul_arm64.h
@@ -55,15 +55,15 @@
 	UMULH R4, R6, R27 \
 	MUL R4, R7, R0 \
 	ADCS R0, R27 \
-	UMULH R4, R7, R29 \
+	UMULH R4, R7, R6 \
 	MUL R4, R8, R0 \
-	ADCS R0, R29 \
+	ADCS R0, R6 \
 	UMULH R4, R8, c7 \
 	ADCS ZR, c7 \
 	ADDS R1, c3 \
 	ADCS R26, c4 \
 	ADCS R27, c5 \
-	ADCS R29, c6 \
+	ADCS R6, c6 \
 	ADCS  ZR, c7
 
 #define gfpReduce() \
@@ -121,6 +121,7 @@
 	ADCS R16, R24 \
 	ADCS  ZR, R0 \
 	\
+	MOVD ·p2+8(SB), R6 \ // Restore R6
 	\ // Our output is R21:R22:R23:R24. Reduce mod p if necessary.
 	SUBS R5, R21, R10 \
 	SBCS R6, R22, R11 \

--- a/mul_arm64.h
+++ b/mul_arm64.h
@@ -19,15 +19,15 @@
 	UMULH R2, R6, R27 \
 	MUL R2, R7, R0 \
 	ADCS R0, R27 \
-	UMULH R2, R7, R29 \
+	UMULH R2, R7, c7 \
 	MUL R2, R8, R0 \
-	ADCS R0, R29 \
+	ADCS R0, c7 \
 	UMULH R2, R8, c5 \
 	ADCS ZR, c5 \
 	ADDS R1, c1 \
 	ADCS R26, c2 \
 	ADCS R27, c3 \
-	ADCS R29, c4 \
+	ADCS c7, c4 \
 	ADCS  ZR, c5 \
 	\
 	MUL R3, R5, R1 \
@@ -37,15 +37,15 @@
 	UMULH R3, R6, R27 \
 	MUL R3, R7, R0 \
 	ADCS R0, R27 \
-	UMULH R3, R7, R29 \
+	UMULH R3, R7, c7 \
 	MUL R3, R8, R0 \
-	ADCS R0, R29 \
+	ADCS R0, c7 \
 	UMULH R3, R8, c6 \
 	ADCS ZR, c6 \
 	ADDS R1, c2 \
 	ADCS R26, c3 \
 	ADCS R27, c4 \
-	ADCS R29, c5 \
+	ADCS c7, c5 \
 	ADCS  ZR, c6 \
 	\
 	MUL R4, R5, R1 \

--- a/mul_arm64.h
+++ b/mul_arm64.h
@@ -1,4 +1,9 @@
-#define mul(c0,c1,c2,c3,c4,c5,c6,c7) \
+#define EMPTY
+
+#define RELOAD \
+	MOVD ·p2+0(SB), R5
+
+#define mul(c0,c1,c2,c3,c4,c5,c6,c7,t0,reset) \
 	MUL R1, R5, c0 \
 	UMULH R1, R5, c1 \
 	MUL R1, R6, R0 \
@@ -34,9 +39,9 @@
 	UMULH R3, R5, R26 \
 	MUL R3, R6, R0 \
 	ADDS R0, R26 \
-	UMULH R3, R6, R27 \
+	UMULH R3, R6, t0 \
 	MUL R3, R7, R0 \
-	ADCS R0, R27 \
+	ADCS R0, t0 \
 	UMULH R3, R7, c7 \
 	MUL R3, R8, R0 \
 	ADCS R0, c7 \
@@ -44,9 +49,11 @@
 	ADCS ZR, c6 \
 	ADDS R1, c2 \
 	ADCS R26, c3 \
-	ADCS R27, c4 \
+	ADCS t0, c4 \
 	ADCS c7, c5 \
 	ADCS  ZR, c6 \
+	\
+	reset \
 	\
 	MUL R4, R5, R1 \
 	UMULH R4, R5, R26 \
@@ -107,7 +114,7 @@
 	\
 	\ // m * N
 	loadModulus(R5,R6,R7,R8) \
-	mul(R17,R25,R19,R20,R21,R22,R23,R24) \
+	mul(R17,R25,R19,R20,R21,R22,R23,R24,R5,RELOAD) \
 	\
 	\ // Add the 512-bit intermediate to m*N
 	MOVD  ZR, R0 \


### PR DESCRIPTION
Resolves #46.

This removes all usage of `R27` and `R29` from `gfpMul`.

This fix introduces 3 additional `MOVD` instructions (1 for the removal of `R29` and 2 for the removal of `R27`).

I couldn't figure out any less costly way of removing the usage of the registers (as all of the available registers are used).

I definitely don't love the style of the change (especially from the last commit where the additional arguments to `mul` were added)... So any suggestions there would be especially appreciated.